### PR TITLE
feat: 회원가입 이메일 전송 비동기 구현 및 가지 않은 메일 처리해주는 스케줄러 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // mail-sender
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 def generated = 'src/main/generated'

--- a/src/main/java/com/market/ElectronicMarketApplication.java
+++ b/src/main/java/com/market/ElectronicMarketApplication.java
@@ -3,10 +3,12 @@ package com.market;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.TimeZone;
 
 @EnableJpaAuditing
+@EnableAsync
 @SpringBootApplication
 public class ElectronicMarketApplication {
 

--- a/src/main/java/com/market/alarm/application/MailEventHandler.java
+++ b/src/main/java/com/market/alarm/application/MailEventHandler.java
@@ -1,36 +1,25 @@
 package com.market.alarm.application;
 
-import com.market.alarm.domain.MailSender;
+import com.market.alarm.domain.MailStorage;
 import com.market.member.domain.auth.RegisteredEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class MailEventHandler {
 
-    private final MailSender mailSender;
+    private final MailService mailService;
 
     @Async
-    @EventListener(RegisteredEvent.class)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendMail(final RegisteredEvent event) {
-        log.info("[" + event.getMemberId() + "번 유저 생성. 닉네임 : " + event.getNickname() + "] : 회원가입 축하 메일 발송 완료");
-
-        try {
-            mailSender.pushMail(event.getEmail(), event.getMemberId(), event.getNickname());
-        } catch (final Exception exception) {
-            handleErrors(event, exception);
-        }
-    }
-
-    private void handleErrors(final RegisteredEvent event, final Exception exception) {
-        log.error("이메일 전송 실패 member : " + event.getMemberId() + " " + event.getEmail());
-        log.error(exception.getMessage());
-
-        // TODO : 에러 핸들링 (메일 재전송)
+        MailStorage mailStorage = MailStorage.createDefault(event.getMemberId(), event.getEmail(), event.getNickname());
+        mailService.sendMail(mailStorage);
     }
 }

--- a/src/main/java/com/market/alarm/application/MailEventHandler.java
+++ b/src/main/java/com/market/alarm/application/MailEventHandler.java
@@ -1,0 +1,36 @@
+package com.market.alarm.application;
+
+import com.market.alarm.domain.MailSender;
+import com.market.member.domain.auth.RegisteredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MailEventHandler {
+
+    private final MailSender mailSender;
+
+    @Async
+    @EventListener(RegisteredEvent.class)
+    public void sendMail(final RegisteredEvent event) {
+        log.info("[" + event.getMemberId() + "번 유저 생성. 닉네임 : " + event.getNickname() + "] : 회원가입 축하 메일 발송 완료");
+
+        try {
+            mailSender.pushMail(event.getEmail(), event.getMemberId(), event.getNickname());
+        } catch (final Exception exception) {
+            handleErrors(event, exception);
+        }
+    }
+
+    private void handleErrors(final RegisteredEvent event, final Exception exception) {
+        log.error("이메일 전송 실패 member : " + event.getMemberId() + " " + event.getEmail());
+        log.error(exception.getMessage());
+
+        // TODO : 에러 핸들링 (메일 재전송)
+    }
+}

--- a/src/main/java/com/market/alarm/application/MailScheduleService.java
+++ b/src/main/java/com/market/alarm/application/MailScheduleService.java
@@ -1,0 +1,22 @@
+package com.market.alarm.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MailScheduleService {
+
+    private final MailService mailService;
+
+    @Scheduled(cron = "0 */10 * * * *")
+    public void resendMail() {
+        mailService.resendMail();
+    }
+
+    @Scheduled(cron = "0 */15 * * * *")
+    public void deleteSendSuccessMails() {
+        mailService.deleteSuccessMails();
+    }
+}

--- a/src/main/java/com/market/alarm/application/MailService.java
+++ b/src/main/java/com/market/alarm/application/MailService.java
@@ -1,0 +1,74 @@
+package com.market.alarm.application;
+
+import com.market.alarm.domain.MailSender;
+import com.market.alarm.domain.MailStorage;
+import com.market.alarm.domain.MailStorageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MailService {
+
+    private static final int THREAD_COUNT = 4;
+
+    private final MailStorageRepository mailStorageRepository;
+    private final MailSender mailSender;
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendMail(final MailStorage mailStorage) {
+        send(mailStorage);
+    }
+
+    private void send(final MailStorage mailStorage) {
+        log.info("{} 번 유저 생성. 닉네임 : {}, 메일 발송 시도!", mailStorage.getReceiverId(), mailStorage.getReceiverNickname());
+
+        try {
+            mailSender.pushMail(mailStorage.getReceiverEmail(), mailStorage.getId(), mailStorage.getReceiverNickname());
+            mailStorage.updateStatusDone();
+            log.info("{} 번 유저 생성. 닉네임 : {}, 메일 발송 성공!", mailStorage.getReceiverId(), mailStorage.getReceiverNickname());
+        } catch (final Exception exception) {
+            handleErrors(mailStorage, exception);
+        }
+    }
+
+    private void handleErrors(final MailStorage mailStorage, final Exception exception) {
+        log.info("{} 번 유저 생성. 닉네임 : {}, 메일 발송 실패!", mailStorage.getReceiverId(), mailStorage.getReceiverNickname());
+        log.error(exception.getMessage());
+
+        mailStorage.updateStatusFail();
+        mailStorageRepository.save(mailStorage);
+    }
+
+    @Transactional
+    public void resendMail() {
+        List<MailStorage> sendFailureMails = mailStorageRepository.findAllByNotDone();
+
+        if (isRunning.compareAndSet(false, true)) {
+            ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+            for (MailStorage sendFailureMail : sendFailureMails) {
+                executorService.submit(() -> send(sendFailureMail));
+            }
+
+            executorService.shutdown();
+            isRunning.set(false);
+            log.info("실패 메일 재전송 성공! 건수: {}", sendFailureMails.size());
+        }
+    }
+
+    @Transactional
+    public void deleteSuccessMails() {
+        mailStorageRepository.deleteAllByDoneMails();
+    }
+}

--- a/src/main/java/com/market/alarm/config/MailSource.java
+++ b/src/main/java/com/market/alarm/config/MailSource.java
@@ -1,4 +1,4 @@
-package com.market.alarm.domain;
+package com.market.alarm.config;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/market/alarm/config/ResendScheduleRunner.java
+++ b/src/main/java/com/market/alarm/config/ResendScheduleRunner.java
@@ -1,0 +1,21 @@
+package com.market.alarm.config;
+
+import com.market.alarm.application.MailScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "schedule.mail", havingValue = "true")
+@Configuration
+public class ResendScheduleRunner implements ApplicationRunner {
+
+    private final MailScheduleService mailScheduleService;
+
+    @Override
+    public void run(final ApplicationArguments args) {
+        mailScheduleService.resendMail();
+    }
+}

--- a/src/main/java/com/market/alarm/domain/MailSender.java
+++ b/src/main/java/com/market/alarm/domain/MailSender.java
@@ -1,0 +1,12 @@
+package com.market.alarm.domain;
+
+import jakarta.mail.MessagingException;
+
+import java.io.UnsupportedEncodingException;
+
+public interface MailSender {
+
+    void pushMail(final String receiver,
+                  final Long id,
+                  final String nickname) throws MessagingException, UnsupportedEncodingException;
+}

--- a/src/main/java/com/market/alarm/domain/MailSource.java
+++ b/src/main/java/com/market/alarm/domain/MailSource.java
@@ -1,0 +1,35 @@
+package com.market.alarm.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum MailSource {
+
+    TITLE("E-market 회원가입 성공 안내"),
+    CONTENT("""
+                    <h1> E-market </h1>
+                    <br>
+                    <p>E-market 회원가입에 성공하셨습니다.<p>
+                    <br>
+                    <p>해당 이메일은 회원가입 성공 안내 메시지입니다.<p>
+                    <br>
+                    <p>회원가입 기념 쿠폰을 발급하였습니다.<p>
+                    <br>
+            """);
+
+    private final String message;
+
+    public static String getMailMessage(final Long id, final String nickname) {
+        String message = "";
+
+        message += TITLE.message;
+        message += "<div style='margin:100px;'>";
+        message += "<p>" + id + "번 유저인" + nickname + "님 환영합니다.<p>";
+        message += CONTENT.message;
+        message += "</div>";
+
+        return message;
+    }
+}

--- a/src/main/java/com/market/alarm/domain/MailStatus.java
+++ b/src/main/java/com/market/alarm/domain/MailStatus.java
@@ -1,0 +1,8 @@
+package com.market.alarm.domain;
+
+public enum MailStatus {
+
+    WAIT,
+    FAIL,
+    DONE
+}

--- a/src/main/java/com/market/alarm/domain/MailStorage.java
+++ b/src/main/java/com/market/alarm/domain/MailStorage.java
@@ -1,0 +1,70 @@
+package com.market.alarm.domain;
+
+import com.market.global.domain.BaseEntity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@EqualsAndHashCode(of = "id", callSuper = false)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MailStorage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private Receiver receiver;
+
+    @Enumerated(value = EnumType.STRING)
+    private MailStatus mailStatus;
+
+    public static MailStorage createDefault(final Long memberId, final String email, final String nickname) {
+        return getMailStorage(memberId, email, nickname, MailStatus.WAIT);
+    }
+
+    public static MailStorage createByStatus(final Long memberId, final String email, final String nickname, final MailStatus mailStatus) {
+        return getMailStorage(memberId, email, nickname, mailStatus);
+    }
+
+    private static MailStorage getMailStorage(final Long memberId, final String email, final String nickname, final MailStatus mailStatus) {
+        return MailStorage.builder()
+                .receiver(Receiver.createDefault(memberId, email, nickname))
+                .mailStatus(mailStatus)
+                .build();
+    }
+
+    public void updateStatusFail() {
+        this.mailStatus = MailStatus.FAIL;
+    }
+
+    public void updateStatusDone() {
+        this.mailStatus = MailStatus.DONE;
+    }
+
+    public Long getReceiverId() {
+        return receiver.getMemberId();
+    }
+
+    public String getReceiverEmail() {
+        return receiver.getEmail();
+    }
+
+    public String getReceiverNickname() {
+        return receiver.getNickname();
+    }
+}

--- a/src/main/java/com/market/alarm/domain/MailStorageRepository.java
+++ b/src/main/java/com/market/alarm/domain/MailStorageRepository.java
@@ -1,0 +1,12 @@
+package com.market.alarm.domain;
+
+import java.util.List;
+
+public interface MailStorageRepository {
+
+    void save(final MailStorage mailStorage);
+
+    List<MailStorage> findAllByNotDone();
+
+    void deleteAllByDoneMails();
+}

--- a/src/main/java/com/market/alarm/domain/Receiver.java
+++ b/src/main/java/com/market/alarm/domain/Receiver.java
@@ -1,0 +1,28 @@
+package com.market.alarm.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
+public class Receiver {
+
+    private Long memberId;
+    private String email;
+    private String nickname;
+
+    protected static Receiver createDefault(final Long memberId, final String email, final String nickname) {
+        return Receiver.builder()
+                .memberId(memberId)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/market/alarm/infrastructure/EmailSender.java
+++ b/src/main/java/com/market/alarm/infrastructure/EmailSender.java
@@ -1,0 +1,55 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailSender;
+import com.market.alarm.domain.MailSource;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+
+import static jakarta.mail.Message.RecipientType.TO;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EmailSender implements MailSender {
+
+    private static final String CHARSET = "utf-8";
+    private static final String SUBTYPE = "html";
+
+    @Value("${mail.sender.email}")
+    private String email;
+
+    @Value("${mail.sender.name}")
+    private String name;
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void pushMail(final String receiver,
+                         final Long id,
+                         final String nickname) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = createMessage(receiver, id, nickname);
+        javaMailSender.send(message);
+    }
+
+
+    private MimeMessage createMessage(final String receiver,
+                                      final Long id,
+                                      final String nickname) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(TO, receiver);
+        message.setSubject(MailSource.TITLE.getMessage());
+        message.setText(MailSource.getMailMessage(id, nickname), CHARSET, SUBTYPE);
+        message.setFrom(new InternetAddress(email, name));
+
+        return message;
+    }
+}

--- a/src/main/java/com/market/alarm/infrastructure/EmailSender.java
+++ b/src/main/java/com/market/alarm/infrastructure/EmailSender.java
@@ -1,7 +1,7 @@
 package com.market.alarm.infrastructure;
 
+import com.market.alarm.config.MailSource;
 import com.market.alarm.domain.MailSender;
-import com.market.alarm.domain.MailSource;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;

--- a/src/main/java/com/market/alarm/infrastructure/MailStorageJdbcRepository.java
+++ b/src/main/java/com/market/alarm/infrastructure/MailStorageJdbcRepository.java
@@ -1,0 +1,20 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class MailStorageJdbcRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public void deleteAllByMailStatus(final MailStatus mailStatus) {
+        String sql = "DELETE FROM mail_storage WHERE mail_status = :mailStatus";
+
+        namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource("mailStatus", mailStatus.name()));
+    }
+}

--- a/src/main/java/com/market/alarm/infrastructure/MailStorageJpaRepository.java
+++ b/src/main/java/com/market/alarm/infrastructure/MailStorageJpaRepository.java
@@ -1,0 +1,14 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailStatus;
+import com.market.alarm.domain.MailStorage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MailStorageJpaRepository extends JpaRepository<MailStorage, Long> {
+
+    MailStorage save(final MailStorage mailStorage);
+
+    List<MailStorage> findAllByMailStatus(final MailStatus mailStatus);
+}

--- a/src/main/java/com/market/alarm/infrastructure/MailStorageRepositoryImpl.java
+++ b/src/main/java/com/market/alarm/infrastructure/MailStorageRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailStatus;
+import com.market.alarm.domain.MailStorage;
+import com.market.alarm.domain.MailStorageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class MailStorageRepositoryImpl implements MailStorageRepository {
+
+    private final MailStorageJpaRepository mailStorageJpaRepository;
+    private final MailStorageJdbcRepository mailStorageJdbcRepository;
+
+    @Override
+    public void save(final MailStorage mailStorage) {
+        mailStorageJpaRepository.save(mailStorage);
+    }
+
+    @Override
+    public List<MailStorage> findAllByNotDone() {
+        return mailStorageJpaRepository.findAllByMailStatus(MailStatus.FAIL);
+    }
+
+    @Override
+    public void deleteAllByDoneMails() {
+        mailStorageJdbcRepository.deleteAllByMailStatus(MailStatus.DONE);
+    }
+}

--- a/src/main/java/com/market/global/config/EventsConfiguration.java
+++ b/src/main/java/com/market/global/config/EventsConfiguration.java
@@ -1,0 +1,20 @@
+package com.market.global.config;
+
+import com.market.global.event.Events;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class EventsConfiguration {
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    public InitializingBean eventInitializer() {
+        return () -> Events.setPublisher(applicationContext);
+    }
+}

--- a/src/main/java/com/market/global/config/MailConfig.java
+++ b/src/main/java/com/market/global/config/MailConfig.java
@@ -1,0 +1,48 @@
+package com.market.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    private static final int MAIL_SERVER_PORT = 465;
+
+    @Value("${mail.host}")
+    private String host;
+    @Value("${mail.username}")
+    private String username;
+    @Value("${mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(MAIL_SERVER_PORT);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+
+        properties.setProperty("mail.transport.protocol", "smtp");
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        properties.setProperty("mail.debug", "false");
+        properties.setProperty("mail.smtp.ssl.trust", host);
+        properties.setProperty("mail.smtp.ssl.enable", "true");
+
+        return properties;
+    }
+}

--- a/src/main/java/com/market/global/config/ScheduleConfig.java
+++ b/src/main/java/com/market/global/config/ScheduleConfig.java
@@ -1,0 +1,11 @@
+package com.market.global.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Component;
+
+@ConditionalOnProperty(name = "schedule.enable", havingValue = "true")
+@EnableScheduling
+@Component
+public class ScheduleConfig {
+}

--- a/src/main/java/com/market/global/event/Event.java
+++ b/src/main/java/com/market/global/event/Event.java
@@ -1,0 +1,13 @@
+package com.market.global.event;
+
+import lombok.Getter;
+
+@Getter
+public abstract class Event {
+
+    private final Long timestamp;
+
+    protected Event() {
+        this.timestamp = System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/market/global/event/Events.java
+++ b/src/main/java/com/market/global/event/Events.java
@@ -1,0 +1,18 @@
+package com.market.global.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class Events {
+
+    private static ApplicationEventPublisher publisher;
+
+    public static void setPublisher(final ApplicationEventPublisher publisher) {
+        Events.publisher = publisher;
+    }
+
+    public static void raise(final Object event) {
+        if (publisher != null) {
+            publisher.publishEvent(event);
+        }
+    }
+}

--- a/src/main/java/com/market/member/application/auth/AuthService.java
+++ b/src/main/java/com/market/member/application/auth/AuthService.java
@@ -1,7 +1,9 @@
 package com.market.member.application.auth;
 
+import com.market.global.event.Events;
 import com.market.member.application.auth.dto.LoginRequest;
 import com.market.member.application.auth.dto.SignupRequest;
+import com.market.member.domain.auth.RegisteredEvent;
 import com.market.member.domain.auth.TokenProvider;
 import com.market.member.domain.member.Member;
 import com.market.member.domain.member.MemberRepository;
@@ -24,7 +26,10 @@ public class AuthService {
     public String signup(final SignupRequest request) {
         Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         validateExistedMember(request.email());
+
         Member signupMember = memberRepository.save(member);
+        Events.raise(new RegisteredEvent(member.getId(), member.getEmail(), member.getNickname()));
+
         return tokenProvider.create(signupMember.getId());
     }
 

--- a/src/main/java/com/market/member/application/auth/AuthService.java
+++ b/src/main/java/com/market/member/application/auth/AuthService.java
@@ -5,9 +5,9 @@ import com.market.member.application.auth.dto.SignupRequest;
 import com.market.member.domain.auth.TokenProvider;
 import com.market.member.domain.member.Member;
 import com.market.member.domain.member.MemberRepository;
+import com.market.member.domain.member.NicknameGenerator;
 import com.market.member.exception.exceptions.member.MemberAlreadyExistedException;
 import com.market.member.exception.exceptions.member.MemberNotFoundException;
-import com.market.member.exception.exceptions.member.PasswordNotMatchedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private final TokenProvider tokenProvider;
     private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final NicknameGenerator nicknameGenerator;
 
     @Transactional
     public String signup(final SignupRequest request) {
-        Member member = Member.createDefaultRole(request.email(), request.password(), request.nickname());
+        Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         validateExistedMember(request.email());
         Member signupMember = memberRepository.save(member);
         return tokenProvider.create(signupMember.getId());
@@ -36,7 +37,7 @@ public class AuthService {
     @Transactional(readOnly = true)
     public String login(final LoginRequest request) {
         Member member = findMemberByEmail(request.email());
-        validatePassword(request.password(), member);
+        member.validatePassword(request.password());
 
         return tokenProvider.create(member.getId());
     }
@@ -44,11 +45,5 @@ public class AuthService {
     private Member findMemberByEmail(final String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new);
-    }
-
-    private void validatePassword(final String password, final Member member) {
-        if (!member.hasSamePassword(password)) {
-            throw new PasswordNotMatchedException();
-        }
     }
 }

--- a/src/main/java/com/market/member/application/auth/AuthService.java
+++ b/src/main/java/com/market/member/application/auth/AuthService.java
@@ -24,9 +24,9 @@ public class AuthService {
 
     @Transactional
     public String signup(final SignupRequest request) {
-        Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         validateExistedMember(request.email());
 
+        Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         Member signupMember = memberRepository.save(member);
         Events.raise(new RegisteredEvent(member.getId(), member.getEmail(), member.getNickname()));
 

--- a/src/main/java/com/market/member/application/auth/dto/SignupRequest.java
+++ b/src/main/java/com/market/member/application/auth/dto/SignupRequest.java
@@ -3,9 +3,6 @@ package com.market.member.application.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignupRequest(
-        @NotBlank(message = "닉네임을 입력해주세요.")
-        String nickname,
-
         @NotBlank(message = "이메일을 입력해주세요.")
         String email,
 

--- a/src/main/java/com/market/member/domain/auth/RegisteredEvent.java
+++ b/src/main/java/com/market/member/domain/auth/RegisteredEvent.java
@@ -1,0 +1,14 @@
+package com.market.member.domain.auth;
+
+import com.market.global.event.Event;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RegisteredEvent extends Event {
+
+    private final Long memberId;
+    private final String email;
+    private final String nickname;
+}

--- a/src/main/java/com/market/member/domain/member/Member.java
+++ b/src/main/java/com/market/member/domain/member/Member.java
@@ -1,5 +1,7 @@
 package com.market.member.domain.member;
 
+import com.market.global.domain.BaseEntity;
+import com.market.member.exception.exceptions.member.PasswordNotMatchedException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,11 +18,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,16 +47,18 @@ public class Member {
 
     public static Member createDefaultRole(final String email,
                                            final String password,
-                                           final String nickname) {
+                                           final NicknameGenerator nicknameGenerator) {
         return Member.builder()
                 .email(email)
                 .password(password)
-                .nickname(nickname)
+                .nickname(nicknameGenerator.createRandomNickname())
                 .memberRole(MemberRole.MEMBER)
                 .build();
     }
 
-    public boolean hasSamePassword(final String password) {
-        return this.password.equals(password);
+    public void validatePassword(final String password) {
+        if (!this.password.equals(password)) {
+            throw new PasswordNotMatchedException();
+        }
     }
 }

--- a/src/main/java/com/market/member/domain/member/NicknameGenerator.java
+++ b/src/main/java/com/market/member/domain/member/NicknameGenerator.java
@@ -1,0 +1,6 @@
+package com.market.member.domain.member;
+
+public interface NicknameGenerator {
+
+    String createRandomNickname();
+}

--- a/src/main/java/com/market/member/infrastructure/member/NicknameCandidate.java
+++ b/src/main/java/com/market/member/infrastructure/member/NicknameCandidate.java
@@ -1,0 +1,22 @@
+package com.market.member.infrastructure.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NicknameCandidate {
+
+    CANDIDATE_01("강아지"),
+    CANDIDATE_02("고양이"),
+    CANDIDATE_03("돼지"),
+    CANDIDATE_04("기린"),
+    CANDIDATE_05("원숭이");
+
+    private final String candidate;
+
+    public static String getCandidate() {
+        int pick = (int) (Math.random() * values().length);
+        return values()[pick].candidate;
+    }
+}

--- a/src/main/java/com/market/member/infrastructure/member/NicknameGeneratorImpl.java
+++ b/src/main/java/com/market/member/infrastructure/member/NicknameGeneratorImpl.java
@@ -1,0 +1,29 @@
+package com.market.member.infrastructure.member;
+
+import com.market.member.domain.member.NicknameGenerator;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class NicknameGeneratorImpl implements NicknameGenerator {
+
+    private static final String SEPARATOR = "-";
+    private static final String BLANK = "";
+    private static final int LENGTH_OF_UUID = 8;
+
+    @Override
+    public String createRandomNickname() {
+        return NicknamePrefix.getPrefix() +
+                NicknameCandidate.getCandidate() +
+                "_" +
+                generateUUID();
+
+    }
+
+    private String generateUUID() {
+        return UUID.randomUUID().toString()
+                .replaceAll(SEPARATOR, BLANK)
+                .substring(0, LENGTH_OF_UUID);
+    }
+}

--- a/src/main/java/com/market/member/infrastructure/member/NicknamePrefix.java
+++ b/src/main/java/com/market/member/infrastructure/member/NicknamePrefix.java
@@ -1,0 +1,22 @@
+package com.market.member.infrastructure.member;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NicknamePrefix {
+
+    PREFIX_01("현명한"),
+    PREFIX_02("귀여운"),
+    PREFIX_03("검정색의"),
+    PREFIX_04("핑크색의"),
+    PREFIX_05("매력적인");
+
+    private final String prefix;
+
+    public static String getPrefix() {
+        int pick = (int) (Math.random() * values().length);
+        return values()[pick].prefix;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
     properties:
       hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,3 +17,7 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+
+schedule:
+  enable: true
+  mail: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,13 @@ server:
 spring:
   profiles:
     active: local
+  datasource:
+    hikari:
+      maximum-pool-size: 5
+  task:
+    scheduling:
+      pool:
+        size: 10
 
 jasypt:
   encryptor:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,11 @@ jasypt:
 jwt:
   secret: ENC(Tnm4CPIFdSiqmH67nWcDfRgaKmpSr4EvRJYZAYLiwOXazIY9aZnLBMlxQnKC2C0j10l6zkOEbRMKIa2W4u7DtIRjCC7QEzCSCdtm1NCEntKRybirDvUH8g==)
   expiration-period: ENC(wtkJPr944E3bs6eMwjj4lQ==)
+
+mail:
+  host: ENC(2PviuayFL6dKe91WydIBx81bpSBoI3FU)
+  username: ENC(Hj0Qwzuifugz4sfvDCq9H0u7+WZC4nL+)
+  password: ENC(WmCiOlJl61IIAfUIuIkWgKjXEE1GLIL5)
+  sender:
+    email: ENC(Pv5Gvm0N7LAl4wx51TrKXrkDENW2VIvpW4Ae3ZIod+I=)
+    name: ENC(mCgRGGxEhhOBxoVnSOrbJxKMEWBjrDLd)

--- a/src/test/java/com/market/alarm/application/MailEventHandlerTest.java
+++ b/src/test/java/com/market/alarm/application/MailEventHandlerTest.java
@@ -1,35 +1,33 @@
 package com.market.alarm.application;
 
 import com.market.helper.IntegrationHelper;
-import com.market.member.domain.auth.RegisteredEvent;
+import com.market.member.application.auth.AuthService;
+import com.market.member.application.auth.dto.SignupRequest;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.ApplicationContext;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class MailEventHandlerTest extends IntegrationHelper {
 
-    @Autowired
-    private ApplicationContext applicationContext;
-
     @MockBean
     private MailEventHandler mailEventHandler;
 
+    @Autowired
+    private AuthService authService;
+
     @Test
     void 회원가입_이벤트가_발행되면_구독자가_동작한다() {
-        // given
-        RegisteredEvent event = new RegisteredEvent(1L, "email@email.com", "nickname");
-
         // when
-        applicationContext.publishEvent(event);
+        authService.signup(new SignupRequest("email@email.com", "1234"));
 
         // then
-        verify(mailEventHandler).sendMail(event);
+        verify(mailEventHandler).sendMail(any());
     }
 }

--- a/src/test/java/com/market/alarm/application/MailEventHandlerTest.java
+++ b/src/test/java/com/market/alarm/application/MailEventHandlerTest.java
@@ -1,0 +1,35 @@
+package com.market.alarm.application;
+
+import com.market.helper.IntegrationHelper;
+import com.market.member.domain.auth.RegisteredEvent;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MailEventHandlerTest extends IntegrationHelper {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @MockBean
+    private MailEventHandler mailEventHandler;
+
+    @Test
+    void 회원가입_이벤트가_발행되면_구독자가_동작한다() {
+        // given
+        RegisteredEvent event = new RegisteredEvent(1L, "email@email.com", "nickname");
+
+        // when
+        applicationContext.publishEvent(event);
+
+        // then
+        verify(mailEventHandler).sendMail(event);
+    }
+}

--- a/src/test/java/com/market/alarm/fxiture/MailStorageFixture.java
+++ b/src/test/java/com/market/alarm/fxiture/MailStorageFixture.java
@@ -1,0 +1,16 @@
+package com.market.alarm.fxiture;
+
+import com.market.alarm.domain.MailStatus;
+import com.market.alarm.domain.MailStorage;
+
+public class MailStorageFixture {
+
+    public static MailStorage 이메일_저장소_생성(
+            final Long memberId,
+            final String email,
+            final String nickname,
+            final MailStatus mailStatus
+    ) {
+        return MailStorage.createByStatus(memberId, email, nickname, mailStatus);
+    }
+}

--- a/src/test/java/com/market/alarm/infrastructure/EmailSenderTest.java
+++ b/src/test/java/com/market/alarm/infrastructure/EmailSenderTest.java
@@ -1,0 +1,47 @@
+package com.market.alarm.infrastructure;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmailSenderTest {
+
+    private EmailSender emailSender;
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @BeforeEach
+    void setup() {
+        emailSender = new EmailSender(javaMailSender);
+    }
+
+    @Test
+    void 메일을_전송한다() throws MessagingException, UnsupportedEncodingException {
+        // given
+        String receiver = "to";
+        Long id = 1L;
+        String nickname = "nickname";
+        MimeMessage message = mock(MimeMessage.class);
+
+        when(javaMailSender.createMimeMessage()).thenReturn(message);
+
+        // when
+        emailSender.pushMail(receiver, id, nickname);
+
+        // then
+        verify(javaMailSender).send(message);
+    }
+}

--- a/src/test/java/com/market/alarm/infrastructure/MailStorageJdbcRepositoryTest.java
+++ b/src/test/java/com/market/alarm/infrastructure/MailStorageJdbcRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailStatus;
+import com.market.alarm.domain.MailStorage;
+import com.market.helper.JdbcTestHelper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.market.alarm.fxiture.MailStorageFixture.이메일_저장소_생성;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MailStorageJdbcRepositoryTest extends JdbcTestHelper {
+
+    @Autowired
+    private MailStorageJpaRepository mailStorageJpaRepository;
+
+    @Autowired
+    private MailStorageJdbcRepository mailStorageJdbcRepository;
+
+    @Test
+    void 메일_상태에_기반하여_batch_제거한다() {
+        // given
+        Long memberId = 1L;
+        String email = "email@email.com";
+        String nickname = "nickname";
+
+        MailStatus done = MailStatus.DONE;
+        MailStatus wait = MailStatus.WAIT;
+
+        mailStorageJpaRepository.save(이메일_저장소_생성(memberId, email, nickname, done));
+        mailStorageJpaRepository.save(이메일_저장소_생성(2L, email + "m", nickname + "m", wait));
+
+        // when
+        mailStorageJdbcRepository.deleteAllByMailStatus(done);
+
+        // then
+        List<MailStorage> deleted = mailStorageJpaRepository.findAllByMailStatus(done);
+        List<MailStorage> waited = mailStorageJpaRepository.findAllByMailStatus(wait);
+
+        assertSoftly(softly -> {
+            softly.assertThat(deleted).isEmpty();
+            softly.assertThat(waited).hasSize(1);
+        });
+    }
+}

--- a/src/test/java/com/market/alarm/infrastructure/MailStorageJpaRepositoryTest.java
+++ b/src/test/java/com/market/alarm/infrastructure/MailStorageJpaRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.market.alarm.infrastructure;
+
+import com.market.alarm.domain.MailStatus;
+import com.market.alarm.domain.MailStorage;
+import com.market.helper.JdbcTestHelper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.market.alarm.fxiture.MailStorageFixture.이메일_저장소_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MailStorageJpaRepositoryTest extends JdbcTestHelper {
+
+    @Autowired
+    private MailStorageJpaRepository mailStorageJpaRepository;
+
+    @Test
+    void 이메일_전송_상태를_저장한다() {
+        // given
+        Long memberId = 1L;
+        String email = "email@email.com";
+        String nickname = "nickname";
+        MailStatus mailStatus = MailStatus.DONE;
+
+        MailStorage storage = 이메일_저장소_생성(memberId, email, nickname, mailStatus);
+
+        // when
+        MailStorage result = mailStorageJpaRepository.save(storage);
+
+        // then
+        assertThat(storage).usingRecursiveComparison()
+                .ignoringFields("id")
+                .isEqualTo(result);
+    }
+
+    @Test
+    void 메일_상태에_기반하여_찾는다() {
+        // given
+        Long memberId = 1L;
+        String email = "email@email.com";
+        String nickname = "nickname";
+        MailStatus mailStatus = MailStatus.DONE;
+        MailStorage savedStorage = mailStorageJpaRepository.save(이메일_저장소_생성(memberId, email, nickname, mailStatus));
+
+        // when
+        List<MailStorage> result = mailStorageJpaRepository.findAllByMailStatus(mailStatus);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0))
+                    .usingRecursiveComparison()
+                    .isEqualTo(savedStorage);
+        });
+    }
+}

--- a/src/test/java/com/market/alarm/infrastructure/MailStorageJpaRepositoryTest.java
+++ b/src/test/java/com/market/alarm/infrastructure/MailStorageJpaRepositoryTest.java
@@ -2,11 +2,11 @@ package com.market.alarm.infrastructure;
 
 import com.market.alarm.domain.MailStatus;
 import com.market.alarm.domain.MailStorage;
-import com.market.helper.JdbcTestHelper;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 
@@ -16,7 +16,8 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class MailStorageJpaRepositoryTest extends JdbcTestHelper {
+@DataJpaTest
+class MailStorageJpaRepositoryTest {
 
     @Autowired
     private MailStorageJpaRepository mailStorageJpaRepository;

--- a/src/test/java/com/market/member/application/auth/AuthServiceTest.java
+++ b/src/test/java/com/market/member/application/auth/AuthServiceTest.java
@@ -9,6 +9,7 @@ import com.market.member.exception.exceptions.member.MemberAlreadyExistedExcepti
 import com.market.member.exception.exceptions.member.MemberNotFoundException;
 import com.market.member.exception.exceptions.member.PasswordNotMatchedException;
 import com.market.member.infrastructure.member.MemberFakeRepository;
+import com.market.member.infrastructure.member.NicknameFakeGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -39,7 +40,7 @@ class AuthServiceTest {
     @BeforeEach
     void setup() {
         memberRepository = new MemberFakeRepository();
-        authService = new AuthService(tokenProvider, memberRepository);
+        authService = new AuthService(memberRepository, tokenProvider, new NicknameFakeGenerator());
     }
 
     @DisplayName("회원가입을 진행한다")
@@ -49,7 +50,7 @@ class AuthServiceTest {
         @Test
         void 회원가입을_성공한다() {
             // given
-            SignupRequest req = new SignupRequest("nickname", "email", "password");
+            SignupRequest req = new SignupRequest("email", "password");
 
             String expectedToken = "token";
             when(tokenProvider.create(anyLong())).thenReturn(expectedToken);
@@ -67,7 +68,7 @@ class AuthServiceTest {
             Member existedMember = 일반_유저_생성();
             memberRepository.save(existedMember);
 
-            SignupRequest req = new SignupRequest("nickname", existedMember.getEmail(), "password");
+            SignupRequest req = new SignupRequest(existedMember.getEmail(), "password");
 
             // when & then
             assertThatThrownBy(() -> authService.signup(req))

--- a/src/test/java/com/market/member/domain/member/MemberTest.java
+++ b/src/test/java/com/market/member/domain/member/MemberTest.java
@@ -1,5 +1,8 @@
 package com.market.member.domain.member;
 
+import com.market.member.exception.exceptions.member.PasswordNotMatchedException;
+import com.market.member.infrastructure.member.NicknameFakeGenerator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -7,10 +10,19 @@ import org.junit.jupiter.api.Test;
 import static com.market.member.fixture.member.MemberFixture.어드민_유저_생성;
 import static com.market.member.fixture.member.MemberFixture.일반_유저_생성;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 class MemberTest {
+
+    private NicknameGenerator nicknameGenerator;
+
+    @BeforeEach
+    void setup() {
+        nicknameGenerator = new NicknameFakeGenerator();
+    }
 
     @Test
     void 어드민인_경우에_true를_반환한다() {
@@ -25,15 +37,25 @@ class MemberTest {
     }
 
     @Test
-    void 패스워드가_다른_경우에_false를_반환한다() {
+    void 패스워드가_다른_경우에_예외를_발생한다() {
         // given
         Member member = 일반_유저_생성();
         String givenPassword = "wrongPassword";
 
+        // when & then
+        assertThatThrownBy(() -> member.validatePassword(givenPassword))
+                .isInstanceOf(PasswordNotMatchedException.class);
+    }
+
+    @Test
+    void 회원가입시_기본적으로_MEMBER_ROLE과_랜덤한_닉네임으로_생성된다() {
         // when
-        boolean result = member.hasSamePassword(givenPassword);
+        Member member = Member.createDefaultRole("email@email.com", "password", nicknameGenerator);
 
         // then
-        assertThat(result).isFalse();
+        assertSoftly(softly -> {
+            softly.assertThat(member.getMemberRole()).isEqualTo(MemberRole.MEMBER);
+            softly.assertThat(member.getNickname()).isEqualTo("nickname");
+        });
     }
 }

--- a/src/test/java/com/market/member/infrastructure/member/MemberJpaRepositoryTest.java
+++ b/src/test/java/com/market/member/infrastructure/member/MemberJpaRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.market.member.infrastructure.member;
 
-import com.market.helper.JdbcTestHelper;
 import com.market.member.domain.member.Member;
-import com.market.member.domain.member.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -10,6 +8,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.Optional;
 
@@ -18,10 +17,11 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
-class MemberJpaRepositoryTest extends JdbcTestHelper {
+@DataJpaTest
+class MemberJpaRepositoryTest {
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberJpaRepository memberRepository;
 
     private Member member;
 

--- a/src/test/java/com/market/member/infrastructure/member/NicknameFakeGenerator.java
+++ b/src/test/java/com/market/member/infrastructure/member/NicknameFakeGenerator.java
@@ -1,0 +1,13 @@
+package com.market.member.infrastructure.member;
+
+import com.market.member.domain.member.NicknameGenerator;
+
+public class NicknameFakeGenerator implements NicknameGenerator {
+
+    private static final String FAKE_NICKNAME = "nickname";
+
+    @Override
+    public String createRandomNickname() {
+        return FAKE_NICKNAME;
+    }
+}

--- a/src/test/java/com/market/member/infrastructure/member/NicknameGeneratorImplTest.java
+++ b/src/test/java/com/market/member/infrastructure/member/NicknameGeneratorImplTest.java
@@ -1,0 +1,24 @@
+package com.market.member.infrastructure.member;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NicknameGeneratorImplTest {
+
+    private final NicknameGeneratorImpl nicknameGenerator = new NicknameGeneratorImpl();
+
+    @Test
+    void 닉네임이_성공적으로_생성된다() {
+        // when
+        String createdNickname = nicknameGenerator.createRandomNickname();
+
+        // then
+        assertThat(createdNickname).isNotBlank();
+    }
+
+}

--- a/src/test/java/com/market/member/ui/auth/AuthControllerAcceptedTestFixture.java
+++ b/src/test/java/com/market/member/ui/auth/AuthControllerAcceptedTestFixture.java
@@ -3,7 +3,6 @@ package com.market.member.ui.auth;
 import com.market.helper.IntegrationHelper;
 import com.market.member.application.auth.dto.LoginRequest;
 import com.market.member.application.auth.dto.SignupRequest;
-import com.market.member.domain.auth.TokenProvider;
 import com.market.member.domain.member.Member;
 import com.market.member.ui.auth.dto.TokenResponse;
 import io.restassured.RestAssured;
@@ -13,11 +12,10 @@ import org.junit.jupiter.api.function.Executable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 class AuthControllerAcceptedTestFixture extends IntegrationHelper {
 
     protected SignupRequest 회원_가입_데이터를_요청한다() {
-        return new SignupRequest("nickname", "email", "password");
+        return new SignupRequest("email", "password");
     }
 
     protected <T> ExtractableResponse 요청(final T request, final String url) {

--- a/src/test/java/com/market/member/ui/auth/AuthControllerWebMvcTest.java
+++ b/src/test/java/com/market/member/ui/auth/AuthControllerWebMvcTest.java
@@ -36,7 +36,7 @@ class AuthControllerWebMvcTest extends MockBeanInjection {
     @Test
     void 회원가입을_진행한다() throws Exception {
         // given
-        SignupRequest req = new SignupRequest("nickname", "email@email.com", "passsword");
+        SignupRequest req = new SignupRequest("email@email.com", "passsword");
         when(authService.signup(req)).thenReturn("response_token_info");
 
         // when & then
@@ -46,7 +46,6 @@ class AuthControllerWebMvcTest extends MockBeanInjection {
                 ).andExpect(status().isOk())
                 .andDo(customDocument("do_signup",
                         requestFields(
-                                fieldWithPath("nickname").description("닉네임"),
                                 fieldWithPath("email").description("이메일"),
                                 fieldWithPath("password").description("패스워드")
                         ),

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,3 +36,6 @@ mail:
     email: email@email.com
     name: e-market
 
+schedule:
+  enable: true
+  mail: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,3 +21,12 @@ jasypt:
 jwt:
   secret: fortestfortestfortestfortestfortestfortestfortestfortestfortestfortestfortestfortestfortestfortestfortest
   expiration-period: 10000
+
+mail:
+  host: smtp.blabla.com
+  username: username
+  password: password
+  sender:
+    email: email@email.com
+    name: e-market
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,6 +14,12 @@ spring:
   flyway:
     enabled: false
 
+logging:
+  level:
+    org:
+      springframework:
+        jdbc: debug
+
 jasypt:
   encryptor:
     password: password


### PR DESCRIPTION
## 📄 Summary

- [x] 현재 응용 계층 회원가입 로직에서 Member 도메인 역할의 로직이 노출되어 있습니다.
이를 도메인 로직으로 리팩토링 진행합니다.
- [x] 회원가입 시 닉네임을 랜덤으로 생성시킵니다. (추후 변경 가능)

## 메일 발송
- [x] 회원가입 시에 가입 축하 메일을 전송합니다. 추후에 메일에는 쿠폰 정보도 함께 발급해줍니다.
- [x] 공통적으로 사용하는 이벤트 설정을 진행 

- [x] 회원가입과 메일 발송 (외부 라이브러리)의 트랜잭션 분리하기
- 만약 회원가입이 완료되었는데, 메일 발송이 지연되는 경우 어떻게 처리?
  - [x] 회원가입 후 메일 발송을 이벤트로 전송 및 해당 부분을 비동기로 처리
- 메일 발송이 안 되었을 때 어떻게 재전송 처리할지?
  - [x] MailStorage를 통해 실패 메일 수집 및 스케쥴링을 통한 재전송 구현

## 🙋🏻 More

https://blog.naver.com/sosow0212/223322476947

close #8