### PR TITLE
refactor: 알림 기능의 트랜잭션 전파 속성 변경 및 메서드 분리를 한다

### DIFF
--- a/src/main/java/com/market/alarm/application/MailScheduleService.java
+++ b/src/main/java/com/market/alarm/application/MailScheduleService.java
@@ -15,7 +15,7 @@ public class MailScheduleService {
         mailService.resendMail();
     }
 
-    @Scheduled(cron = "0 */15 * * * *")
+    @Scheduled(cron = "0 */30 * * * *")
     public void deleteSendSuccessMails() {
         mailService.deleteSuccessMails();
     }


### PR DESCRIPTION
## 📄 Summary

현재 회원가입을 진행하면 메일 알림을 비동기로 보냅니다.

비동기로 새로운 스레드가 sendMail(...) 메서드를 작동시키는데
sendMail의 트랜잭션 전파 속성이 REQUIRES_NEW로 되어있습니다.

어차피 새로운 스레드임으로 해당 속성이 필요 없어 보이고 불필요한 메서드도 리팩토링합니다.

## 🙋🏻 More

[관련된 이전 PR ](https://github.com/sosow0212/2024-electronic-market/pull/9)

close #19