### PR TITLE
refactor: 멀티모듈의 이벤트 구조를 변경시킨다. (Redis pub/sub)

### DIFF
--- a/.github/workflows/market-api-ci.yml
+++ b/.github/workflows/market-api-ci.yml
@@ -6,6 +6,7 @@ on:
       - develop
       - dev
       - prod
+      - refactor/module
 
 permissions:
   contents: read

--- a/.github/workflows/market-batch-ci.yml
+++ b/.github/workflows/market-batch-ci.yml
@@ -6,6 +6,7 @@ on:
       - develop
       - dev
       - prod
+      - refactor/module
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -9,17 +9,35 @@
 
 ## 과정 (진행중)
 
-- [x] Github Actions를 이용한 CI 환경 생성 ([해당 과정 포스팅 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223314392944&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
-- [x] 테스트 격리 유틸 생성 및 REST Docs Helper 생성 ([해당 과정 포스팅 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223315262688&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
-- [x] 회원가입 및 로그인 ([해당 과정 포스팅 및 고민한 점 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223317675973&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
-- [x] 회원가입 이메일 전송 비동기 구현 및 미전송 메일 처리해주는 기능 구현 ([해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223322476947&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
-- [x] 회원 간 커뮤니티 기능 생성 및 동시성 처리 ([다양한 동시성 처리 방법 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223328710499&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+### 인프라
+
+- [x] Github Actions를 이용한 CI 환경
+  생성 ([해당 과정 포스팅 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223314392944&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+- [x] 인프라 환경 구축하기 1차
+    - [x] Jenkins를 이용한 CD 환경
+      구축 ([아키텍처 및 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223369462311&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+    - [x] Prometheus, Grafana 이용한 모니터링
+      구축 ([아키텍처 및 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223369973401&categoryNo=161&parentCategoryNo=152&viewDate=&currentPage=1&postListTopCurrentPage=1&from=thumbnailList&userTopListOpen=true&userTopListCount=5&userTopListManageOpen=false&userTopListCurrentPage=1))
+    - [x] Docker 이미지로 서버를 작동하도록 변경 및 무중단배포
+      적용 ([새로운 아키텍처와 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223371181808&categoryNo=161&parentCategoryNo=152&viewDate=&currentPage=1&postListTopCurrentPage=1&from=thumbnailList&userTopListOpen=true&userTopListCount=5&userTopListManageOpen=false&userTopListCurrentPage=1)))
+
+### 기능 개발
+
+- [x] 테스트 격리 유틸 생성 및 REST Docs Helper
+  생성 ([해당 과정 포스팅 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223315262688&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+- [x] 회원가입 및
+  로그인 ([해당 과정 포스팅 및 고민한 점 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223317675973&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+- [x] 회원가입 이메일 전송 비동기 구현 및 미전송 메일 처리해주는 기능
+  구현 ([해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223322476947&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
+- [x] 회원 간 커뮤니티 기능 생성 및 동시성
+  처리 ([다양한 동시성 처리 방법 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223328710499&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
 - [x] 쿠폰 기능 생성 및 금액 할인 도메인 서비스 구현
 - [x] 마켓에 물품을 올리고 구매할 수 있는 기능 구현
-- [x] 인프라 환경 구축하기 1차
-  - [x] Jenkins를 이용한 CD 환경 구축 ([아키텍처 및 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223369462311&categoryNo=152&parentCategoryNo=152&from=thumbnailList))
-  - [x] Prometheus, Grafana 이용한 모니터링 구축 ([아키텍처 및 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223369973401&categoryNo=161&parentCategoryNo=152&viewDate=&currentPage=1&postListTopCurrentPage=1&from=thumbnailList&userTopListOpen=true&userTopListCount=5&userTopListManageOpen=false&userTopListCurrentPage=1))
-  - [x] Docker 이미지로 서버를 작동하도록 변경 및 무중단배포 적용 ([새로운 아키텍처와 해당 과정 보러가기](https://blog.naver.com/PostView.naver?blogId=sosow0212&logNo=223371181808&categoryNo=161&parentCategoryNo=152&viewDate=&currentPage=1&postListTopCurrentPage=1&from=thumbnailList&userTopListOpen=true&userTopListCount=5&userTopListManageOpen=false&userTopListCurrentPage=1)))
+
+### 아키텍처
+
+- [x] 멀티모듈 분리 -> API, Batch 서버 ([멀티모듈로 분리한 이유](https://blog.naver.com/sosow0212/223401237314))
+    - [x] 기존 이벤트를 Redis pub/sub으로 변경
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ subprojects {
         // db
         runtimeOnly 'com.h2database:h2'
         runtimeOnly 'com.mysql:mysql-connector-j'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
         // flyway
         implementation 'org.flywaydb:flyway-core'

--- a/market-api/src/main/java/com/server/global/config/RedisConfig.java
+++ b/market-api/src/main/java/com/server/global/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.server.global.config;
+
+import com.server.global.event.RedisPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
+    }
+
+    @Bean
+    public InitializingBean redisPublisherInitializer() {
+        return () -> RedisPublisher.setTemplate(redisTemplate());
+    }
+}

--- a/market-api/src/main/java/com/server/global/event/RedisPublisher.java
+++ b/market-api/src/main/java/com/server/global/event/RedisPublisher.java
@@ -1,0 +1,18 @@
+package com.server.global.event;
+
+import org.springframework.data.redis.core.RedisTemplate;
+
+public class RedisPublisher {
+
+    private static RedisTemplate redisTemplate;
+
+    public static void setTemplate(final RedisTemplate redisTemplate) {
+        RedisPublisher.redisTemplate = redisTemplate;
+    }
+
+    public static void raise(final String channel, final Object message) {
+        if (redisTemplate != null) {
+            redisTemplate.convertAndSend(channel, message);
+        }
+    }
+}

--- a/market-api/src/main/java/com/server/member/application/auth/AuthEventListener.java
+++ b/market-api/src/main/java/com/server/member/application/auth/AuthEventListener.java
@@ -1,0 +1,25 @@
+package com.server.member.application.auth;
+
+import com.server.global.event.RedisPublisher;
+import com.server.member.domain.auth.event.RegisteredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthEventListener {
+
+    private static final String PUBLISH_CHANNEL = "auth-mail";
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishMail(final RegisteredEvent event) {
+        RedisPublisher.raise(PUBLISH_CHANNEL, new RegisteredEvent(event.getMemberId(), event.getEmail(), event.getNickname()));
+        log.info("Publisher :: " + PUBLISH_CHANNEL + "채널 " + event.getEmail() + "발행 성공!");
+    }
+}

--- a/market-api/src/main/java/com/server/member/application/auth/AuthEventListener.java
+++ b/market-api/src/main/java/com/server/member/application/auth/AuthEventListener.java
@@ -19,7 +19,7 @@ public class AuthEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publishMail(final RegisteredEvent event) {
-        RedisPublisher.raise(PUBLISH_CHANNEL, new RegisteredEvent(event.getMemberId(), event.getEmail(), event.getNickname()));
+        RedisPublisher.raise(PUBLISH_CHANNEL, event);
         log.info("Publisher :: " + PUBLISH_CHANNEL + "채널 " + event.getEmail() + "발행 성공!");
     }
 }

--- a/market-api/src/main/java/com/server/member/application/auth/AuthService.java
+++ b/market-api/src/main/java/com/server/member/application/auth/AuthService.java
@@ -1,6 +1,6 @@
 package com.server.member.application.auth;
 
-import com.server.global.event.RedisPublisher;
+import com.server.global.event.Events;
 import com.server.member.application.auth.dto.LoginRequest;
 import com.server.member.application.auth.dto.SignupRequest;
 import com.server.member.domain.auth.TokenProvider;
@@ -20,8 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AuthService {
 
-    private static final String PUBLISH_CHANNEL = "auth-mail";
-
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
     private final NicknameGenerator nicknameGenerator;
@@ -33,9 +31,7 @@ public class AuthService {
         Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         Member signupMember = memberRepository.save(member);
 
-        RedisPublisher.raise(PUBLISH_CHANNEL, new RegisteredEvent(member.getId(), member.getEmail(), member.getNickname()));
-        log.info("Publisher :: " + PUBLISH_CHANNEL + "채널 " + member.getEmail() + "발행 성공 !");
-
+        Events.raise(new RegisteredEvent(member.getId(), member.getEmail(), member.getNickname()));
         return tokenProvider.create(signupMember.getId());
     }
 

--- a/market-api/src/main/java/com/server/member/application/auth/AuthService.java
+++ b/market-api/src/main/java/com/server/member/application/auth/AuthService.java
@@ -32,6 +32,7 @@ public class AuthService {
 
         Member member = Member.createDefaultRole(request.email(), request.password(), nicknameGenerator);
         Member signupMember = memberRepository.save(member);
+
         RedisPublisher.raise(PUBLISH_CHANNEL, new RegisteredEvent(member.getId(), member.getEmail(), member.getNickname()));
         log.info("Publisher :: " + PUBLISH_CHANNEL + "채널 " + member.getEmail() + "발행 성공 !");
 

--- a/market-api/src/main/java/com/server/member/domain/auth/event/RegisteredEvent.java
+++ b/market-api/src/main/java/com/server/member/domain/auth/event/RegisteredEvent.java
@@ -4,9 +4,11 @@ import com.server.global.event.Event;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @RequiredArgsConstructor
-public class RegisteredEvent extends Event {
+public class RegisteredEvent extends Event implements Serializable {
 
     private final Long memberId;
     private final String email;

--- a/market-api/src/main/resources/application-local.yml
+++ b/market-api/src/main/resources/application-local.yml
@@ -4,6 +4,10 @@ spring:
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
   flyway:
     enabled: false
@@ -11,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
     properties:
       hibernate:

--- a/market-api/src/main/resources/application-prod.yml
+++ b/market-api/src/main/resources/application-prod.yml
@@ -4,7 +4,10 @@ spring:
     username: ENC(Vt4CpxfngX+cLFkAFmlCjw==)
     password: ENC(Vt4CpxfngX+cLFkAFmlCjw==)
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
   flyway:
     enabled: false
     baseline-on-migrate: false

--- a/market-batch/src/main/java/batch/server/alarm/application/AuthMailMessageListener.java
+++ b/market-batch/src/main/java/batch/server/alarm/application/AuthMailMessageListener.java
@@ -1,0 +1,32 @@
+package batch.server.alarm.application;
+
+import batch.server.alarm.domain.event.RegisteredEvent;
+import batch.server.global.event.Events;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthMailMessageListener implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(final Message message, final byte[] pattern) {
+        try {
+            RegisteredEvent registeredEvent = objectMapper.readValue(message.getBody(), RegisteredEvent.class);
+            log.info("Subscriber :: auth-mail 메시지 수신 성공, " + registeredEvent.email());
+            Events.raise(registeredEvent);
+        } catch (IOException e) {
+            log.error("Subscriber :: auth-mail 메시지 수신 실패, " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/market-batch/src/main/java/batch/server/alarm/application/MailEventHandler.java
+++ b/market-batch/src/main/java/batch/server/alarm/application/MailEventHandler.java
@@ -4,10 +4,8 @@ import batch.server.alarm.domain.MailStorage;
 import batch.server.alarm.domain.event.RegisteredEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -16,10 +14,9 @@ public class MailEventHandler {
 
     private final MailService mailService;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void sendMail(final RegisteredEvent event) {
-        MailStorage mailStorage = MailStorage.createDefault(event.getMemberId(), event.getEmail(), event.getNickname());
+        MailStorage mailStorage = MailStorage.createDefault(event.memberId(), event.email(), event.nickname());
         mailService.sendMail(mailStorage);
     }
 }

--- a/market-batch/src/main/java/batch/server/alarm/application/MailService.java
+++ b/market-batch/src/main/java/batch/server/alarm/application/MailService.java
@@ -38,6 +38,7 @@ public class MailService {
     private void saveFailureSendMail(final MailStorage mailStorage, final Exception exception) {
         log.error("{} 번 유저 닉네임 : {} 메일 발송 실패! 사유 : {}", mailStorage.getReceiverId(), mailStorage.getReceiverNickname(), exception.getCause());
         mailStorage.updateStatusFail();
+        mailStorageRepository.save(mailStorage);
     }
 
     @Transactional

--- a/market-batch/src/main/java/batch/server/alarm/domain/event/RegisteredEvent.java
+++ b/market-batch/src/main/java/batch/server/alarm/domain/event/RegisteredEvent.java
@@ -1,15 +1,12 @@
 package batch.server.alarm.domain.event;
 
-import batch.server.global.event.Event;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import java.io.Serializable;
 
-@Getter
-@RequiredArgsConstructor
-public class RegisteredEvent extends Event {
-
-    private final Long memberId;
-    private final String email;
-    private final String nickname;
+public record RegisteredEvent(
+        Long memberId,
+        String email,
+        String nickname,
+        Long timestamp
+) implements Serializable {
 }
 

--- a/market-batch/src/main/java/batch/server/global/config/RedisConfig.java
+++ b/market-batch/src/main/java/batch/server/global/config/RedisConfig.java
@@ -44,6 +44,7 @@ public class RedisConfig {
     public RedisMessageListenerContainer redisContainer() {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory());
+
         container.addMessageListener(authMailListener(), authMailTopic());
         return container;
     }

--- a/market-batch/src/main/java/batch/server/global/config/RedisConfig.java
+++ b/market-batch/src/main/java/batch/server/global/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package batch.server.global.config;
+
+import batch.server.alarm.application.AuthMailMessageListener;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
+    }
+
+    @Bean
+    public ChannelTopic authMailTopic() {
+        return new ChannelTopic("auth-mail");
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory());
+        container.addMessageListener(authMailListener(), authMailTopic());
+        return container;
+    }
+
+    @Bean
+    public AuthMailMessageListener authMailListener() {
+        return new AuthMailMessageListener(new ObjectMapper());
+    }
+}

--- a/market-batch/src/main/resources/application-local.yml
+++ b/market-batch/src/main/resources/application-local.yml
@@ -4,7 +4,10 @@ spring:
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
   flyway:
     enabled: false
     baseline-on-migrate: false

--- a/market-batch/src/main/resources/application-prod.yml
+++ b/market-batch/src/main/resources/application-prod.yml
@@ -4,7 +4,10 @@ spring:
     username: ENC(Vt4CpxfngX+cLFkAFmlCjw==)
     password: ENC(Vt4CpxfngX+cLFkAFmlCjw==)
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
   flyway:
     enabled: false
     baseline-on-migrate: false


### PR DESCRIPTION
## 📄 Summary

## 문제 상황
멀티모듈로 전환한 후에 메일 전송을 위해서 api 서버에서 생성하는 이벤트를 batch 서버에서 이벤트를 수신할 수 없습니다.

이를 해결하기 위해서 다른 방법으로 이벤트를 수신합니다.
-> Redis pub/sub
-> 유실 이벤트 허용 (batch 존재하므로)

여러가지 메시징 기능을 제공하는 기술 중에서 Redis pub/sub을 선택한 이유는 현재로써는 학습 곡선이 가장 낮다고 생각해서 선택하였습니다.
해당 기술을 사용할 때 메시지를 보관하지 않아서 유실될 수 있다는 문제가 있습니다.

## 플로우
- api 모듈에서 유저가 회원가입을 한다
- api 모듈에서 회원가입 커밋 후 비동기 이벤트를 통해 Redis publish를 작동시킨다. (`auth-mail 채널`)
- batch 모듈에서 auth-mail 채널을 subscribe하고 있으며 이벤트를 받아서 메일 전송을 한다.

## Issue
코드레벨로 충분히 할 수 있지만, 우선순위 작업을 모두 해결한 후 메시지 큐에 대한 더 많은 자료를 접하고 학습을 마친 후
따로 이슈를 생성하여 해결할 예정입니다.


## 🙋🏻 More

>


close #68